### PR TITLE
PayablesTable make deduction date sortable by default

### DIFF
--- a/src/components/Payables.tsx
+++ b/src/components/Payables.tsx
@@ -836,6 +836,7 @@ export function PayablesTable({
     {
       title: 'Deduction Date',
       field: 'deductionDate',
+      orderBy: Mercoa.InvoiceOrderByField.DeductionDate,
     },
   ]
 


### PR DESCRIPTION
No idea if me making a PR here will work or if this is helpful, but here goes nothing.

NOTE: please test this locally, my local has no invoices with deduction dates right now so I wasn't able to test it