### PR TITLE
docs: Avoid spelling out units of measurement

### DIFF
--- a/docs/pages/docs/Legacy/Payables/PayableDetails/Details.mdx
+++ b/docs/pages/docs/Legacy/Payables/PayableDetails/Details.mdx
@@ -14,7 +14,7 @@ import {
   PayablePaymentDestination,
   PayablePaymentSource,
   PaymentDestinationProcessingTime
-} from '@mercoa/react'
+} from '@Mercoa/react'
 import { Callout } from 'nextra/components'
 import { useEffect } from 'react'
 import { ComponentContainer } from '../../../../../components/helpers'

--- a/docs/pages/docs/Legacy/Payables/PayableDetails/Document.mdx
+++ b/docs/pages/docs/Legacy/Payables/PayableDetails/Document.mdx
@@ -2,7 +2,7 @@ import {
   OcrProgressBarV1,
   PayableDocumentDisplayV1,
   DocumentUploadBoxV1
-} from '@mercoa/react'
+} from '@Mercoa/react'
 import { payerEntity, vendorEntities, inv_new_ready, inv_scheduled } from '../../../../../mockData'
 import { ComponentContainer } from '../../../../../components/helpers'
 import { Callout } from 'nextra/components'
@@ -25,7 +25,7 @@ The `<PayableDocument>` component should be used as a child of the [`<PayableDet
 | invoice               | `Mercoa.InvoiceResponse`                                                             |          | The ID of the invoice to edit. Leave blank if creating a new invoice                                                                                  |
 | onOcrComplete         | `(ocrResponse?: Mercoa.OcrResponse) => void`                                         |          | Callback when OCR is completed
 | setUploadedDocument   | `(document: string) => void`                                                         |          | Callback of base64 docuemnt when the document is uploaded                                                                          |
-| height                | `number`                                                                             |   ✅     | Height of the component in pixels |
+| height                | `number`                                                                             |   ✅     | Height of the component in px |
 | theme                 | `'light' \| 'dark'`                                                                  |          |                                                                            |
 | downloadButton        | `({ onClick }: { onClick: () => void }) => JSX.Element`                              |          | Override for download invoice button                                                                                                                                 |
 | viewEmailButton       | `({ onClick }: { onClick: () => void }) => JSX.Element`                              |          | Override for view email invoice button                              |

--- a/docs/pages/docs/Legacy/Payables/PayableDetails/Form.mdx
+++ b/docs/pages/docs/Legacy/Payables/PayableDetails/Form.mdx
@@ -15,7 +15,7 @@ import {
   PayablePaymentSourceV1,
   PaymentDestinationProcessingTimeV1,
   PaymentOptionsV1,
-} from '@mercoa/react'
+} from '@Mercoa/react'
 import { Callout } from 'nextra/components'
 import { useEffect } from 'react'
 import { ComponentContainer } from '../../../../../components/helpers'
@@ -38,7 +38,7 @@ The `<PayableForm>` component should be used as a child of the [`<PayableDetails
 | invoice               | `Mercoa.InvoiceResponse`                                                                                                                                      |          | The invoice object                                                                                                               |
 | ocrResponse           | `Mercoa.OcrResponse`                                                                                                                                          |          | Results of OCR                                                                                                                   |
 | onUpdate              | `(invoice: InvoiceResponse \| undefined) => void`                                                                                                             |          | When the invoice is created, updated, or deleted, this callback is triggered                                                     |
-| height                | `number`                                                                                                                                                      | ✅       | Height of the component in pixels                                                                                                |
+| height                | `number`                                                                                                                                                      | ✅       | Height of the component in px                                                                                                |
 | uploadedDocument      | `string`                                                                                                                                                      |          | base64 encoded invoice document                                                                                                  |
 | setUploadedDocument   | `(e?: string) => void`                                                                                                                                        |          | Overrides for buttons                                                                                                            |
 | invoicePreSubmit      | `(invoice: Mercoa.InvoiceCreationRequest) => Promise<Mercoa.InvoiceCreationRequest>`                                                                          |          | This function is called after frontend validations are complete, and before the API call to create/update the invoice is sent.   |

--- a/docs/pages/docs/Payables/components/PayableDetails.mdx
+++ b/docs/pages/docs/Payables/components/PayableDetails.mdx
@@ -16,7 +16,7 @@ import {
   PayableApprovers,
   PayableComments,
   PayableActions,
-} from '@mercoa/react'
+} from '@Mercoa/react'
 import { ComponentContainer } from '../../../../components/helpers'
 import { inv_new_ready, inv_scheduled, payerEntity, vendorEntities } from '../../../../mockData'
 


### PR DESCRIPTION
- Avoid spelling out units of measurement
  This rule flags instances where units of measurement (like meters, grams, pixels) are spelled out instead of using their abbreviated forms. For better readability and consistency, use abbreviations like 'm', 'g', 'px' instead of spelling out the full unit name.