### PR TITLE
docs: Use "of" instead of "for" with URL

### DIFF
--- a/docs/pages/docs/Legacy/Payables/PayableDetails/Details.mdx
+++ b/docs/pages/docs/Legacy/Payables/PayableDetails/Details.mdx
@@ -14,7 +14,7 @@ import {
   PayablePaymentDestination,
   PayablePaymentSource,
   PaymentDestinationProcessingTime
-} from '@mercoa/react'
+} from '@Mercoa/react'
 import { Callout } from 'nextra/components'
 import { useEffect } from 'react'
 import { ComponentContainer } from '../../../../../components/helpers'

--- a/docs/pages/docs/Legacy/Payables/PayableDetails/Document.mdx
+++ b/docs/pages/docs/Legacy/Payables/PayableDetails/Document.mdx
@@ -2,7 +2,7 @@ import {
   OcrProgressBarV1,
   PayableDocumentDisplayV1,
   DocumentUploadBoxV1
-} from '@mercoa/react'
+} from '@Mercoa/react'
 import { payerEntity, vendorEntities, inv_new_ready, inv_scheduled } from '../../../../../mockData'
 import { ComponentContainer } from '../../../../../components/helpers'
 import { Callout } from 'nextra/components'

--- a/docs/pages/docs/Legacy/Payables/PayableDetails/Form.mdx
+++ b/docs/pages/docs/Legacy/Payables/PayableDetails/Form.mdx
@@ -15,7 +15,7 @@ import {
   PayablePaymentSourceV1,
   PaymentDestinationProcessingTimeV1,
   PaymentOptionsV1,
-} from '@mercoa/react'
+} from '@Mercoa/react'
 import { Callout } from 'nextra/components'
 import { useEffect } from 'react'
 import { ComponentContainer } from '../../../../../components/helpers'

--- a/docs/pages/docs/Payables/components/PayableDetails.mdx
+++ b/docs/pages/docs/Payables/components/PayableDetails.mdx
@@ -16,7 +16,7 @@ import {
   PayableApprovers,
   PayableComments,
   PayableActions,
-} from '@mercoa/react'
+} from '@Mercoa/react'
 import { ComponentContainer } from '../../../../components/helpers'
 import { inv_new_ready, inv_scheduled, payerEntity, vendorEntities } from '../../../../mockData'
 


### PR DESCRIPTION
- Use "of" instead of "for" with URL
  This rule suggests using "of" instead of "for" to describe the relationship of the word URL to a resource, ensuring clarity and adherence to style guidelines.