### PR TITLE
docs: Suggest simple and concise words instead of complex terminology.

### DIFF
--- a/docs/pages/docs/Counterparties/Manage.mdx
+++ b/docs/pages/docs/Counterparties/Manage.mdx
@@ -5,7 +5,7 @@ import { payerEntity, vendorEntities } from '../../../mockData'
 
 # Manage Counterparties
 
-The `<Counterparties>` renders a list of counterparties that can be selected, as well as allowing your user to add a new counterparty
+The `<Counterparties>` renders a list of counterparties that can be selected, and allowing your user to add a new counterparty
 
 ## Customization Options
 

--- a/docs/pages/docs/Entity/OnboardingForm.mdx
+++ b/docs/pages/docs/Entity/OnboardingForm.mdx
@@ -6,7 +6,7 @@ import { ComponentContainer } from '../../../components/helpers'
 
 The `<EntityOnboardingForm>` component is the raw form used to collect onboarding information from your customers (C2) and their counterparties (C3).
 
-Most of the time, you should use the [`<EntityOnboarding`> component](/Entity/Onboarding), but if you want to process the data before it is sent to Mercoa, you can use this component.
+Usually, you should use the [`<EntityOnboarding`> component](/Entity/Onboarding), but to process the data before it is sent to Mercoa, you can use this component.
 
 Fields displayed on the onboarding component are controlled by your [onboarding configuration](https://mercoa.com/dashboard/developers#customizations).
 
@@ -23,7 +23,7 @@ Fields displayed on the onboarding component are controlled by your [onboarding 
 | entity             | `Mercoa.EntityResponse`                | ✅       | The entity to onboard                                                                                                               |
 | type               | `"payee"` `"payor"`                    | ✅       | Use `Payee` to onboard a vendor, and `Payor` to onboard a payer                                                                     |
 | onOnboardingSubmit | `((data: OnboardingFormData) => void)` |          | Callback called with all form data when submitted                                                                                   |
-| admin              | `boolean`                              |          | If true, will show all fields as well as additional fields like `isPayor` and `isPayee`. Useful to build internal admin dashboards. |
+| admin              | `boolean`                              |          | If true, will show all fields and additional fields like `isPayor` and `isPayee`. Useful to build internal admin dashboards. |
 
 ## Examples
 

--- a/docs/pages/docs/Entity/RepresentativeForm.mdx
+++ b/docs/pages/docs/Entity/RepresentativeForm.mdx
@@ -6,7 +6,7 @@ import { ComponentContainer } from '../../../components/helpers'
 
 The `<RepresentativeOnboardingForm>` component is the raw form used to collect new representative information.
 
-Most of the time, you should use the [`<EntityOnboarding`> component](/Entity/Onboarding), but if you want to process the data before it is sent to Mercoa, you can use this component.
+Usually, you should use the [`<EntityOnboarding`> component](/Entity/Onboarding), but to process the data before it is sent to Mercoa, you can use this component.
 
 ## Customization Options
 

--- a/docs/pages/docs/Legacy/Payables/Inbox.mdx
+++ b/docs/pages/docs/Legacy/Payables/Inbox.mdx
@@ -19,7 +19,7 @@ The `<Payables>` component shows all payables for an entity. It has built in fil
 | :--------------------| :-------------------------------------| :--------| :----------------------------------------------------------------------------|
 | statuses             | `Mercoa.InvoiceStatus[]`              |          | List of invoice statuses to display. By default, all statuses are displayed  |
 | onSelectInvoice      | `((invoice: InvoiceResponse) => any)` |          | Function to call when an invoice is clicked                                  |
-| statusSelectionStyle | `"tabs"` `"dropdown"`                 |          | The variation for how to select the currently shown status. Default is tabs. |
+| statusSelectionStyle | `"tabs"` `"dropdown"`                 |          | The variation for how to select the now shown status. Default is tabs. |
 | columns              | `InvoiceTableColumn[]`                |          | List of columns to display, including metadata columns. See [InvoiceTableColumn type for details](./Table)                  |
 
 

--- a/docs/pages/docs/Legacy/Payables/PayableDetails/Document.mdx
+++ b/docs/pages/docs/Legacy/Payables/PayableDetails/Document.mdx
@@ -50,7 +50,7 @@ type PayableDocumentChildrenProps = {
 The `PayableDocument` component consists of multiple subcomponents that can all be customized. Additionally, you can mix in your own custom components to further control the UX.
 
 <Callout>
-All of the subcomponents must be children of a `PayableDocument` component
+all the subcomponents must be children of a `PayableDocument` component
 </Callout>
 
 

--- a/docs/pages/docs/Legacy/Payables/PayableDetails/Form.mdx
+++ b/docs/pages/docs/Legacy/Payables/PayableDetails/Form.mdx
@@ -165,7 +165,7 @@ The default children is the following:
 | Name                          | Type                                                     | Required | Description                                                                            |
 | :---------------------------- | :------------------------------------------------------- | :------- | :------------------------------------------------------------------------------------- |
 | readOnly                      | `boolean`                                                |          | Make data read only                                                                    |
-| supportedCurrencies           | `Array<Mercoa.CurrencyCode>`                             |          | Set supported currencies in addition to the currencies supported by the payment source |
+| supportedCurrencies           | Array<Mercoa.CurrencyCode>                             |          | Set supported currencies also to the currencies supported by the payment source |
 | supportedSchedulePaymentDates | `Array \<'Weekend' \| 'Past' \| 'Holiday'\>`             |          | Set overrides for dates to be enabled for the scheduled payment date                   |
 | children                      | `( props : PayableOverviewChildrenProps) => JSX.Element` |          | Custom Component                                                                       |
 

--- a/docs/pages/docs/Legacy/Payables/Table.mdx
+++ b/docs/pages/docs/Legacy/Payables/Table.mdx
@@ -7,7 +7,7 @@ import { ComponentContainer } from '../../../../components/helpers'
 
 The `<PayablesTableV1>` renders a list of invoices that can be selected or acted on. The component supports multiple filtering options to let you get the data you need, and provides out-of-the-box pagination support.
 
-If you want to render `UNASSIGNED` invoices for an entity group, you can use the `<GroupPayablesTable>` component, which takes the same props as `<PayablesTable>` aside from `statuses`.
+To render `UNASSIGNED` invoices for an entity group, you can use the `<GroupPayablesTable>` component, which takes the same props as `<PayablesTable>` aside from `statuses`.
 
 ## Customization Options
 

--- a/docs/pages/docs/Legacy/Receivables/Inbox.mdx
+++ b/docs/pages/docs/Legacy/Receivables/Inbox.mdx
@@ -18,7 +18,7 @@ The `<ReceivablesV1>` component shows all receivables for an entity. It has buil
 | :--------------------| :-------------------------------------| :--------| :----------------------------------------------------------------------------|
 | statuses             | `Mercoa.InvoiceStatus[]`              |          | List of invoice statuses to display. By default, all statuses are displayed  |
 | onSelectInvoice      | `((invoice: InvoiceResponse) => any)` |          | Function to call when an invoice is clicked                                  |
-| statusSelectionStyle | `"tabs"` `"dropdown"`                 |          | The variation for how to select the currently shown status. Default is tabs. |
+| statusSelectionStyle | `"tabs"` `"dropdown"`                 |          | The variation for how to select the now shown status. Default is tabs. |
 
 
 

--- a/docs/pages/docs/Metrics.mdx
+++ b/docs/pages/docs/Metrics.mdx
@@ -113,7 +113,7 @@ While Mercoa does not ship charts and graphs out of the box, this component can 
 
 ### Graph
 
-We use the `returnByDate` along with a graphing library to create a graph!
+We use the `returnByDate` with a graphing library to create a graph!
 
 <ComponentContainer>
   <InvoiceMetrics 

--- a/docs/pages/docs/Payables/hooks/usePayableDetails.mdx
+++ b/docs/pages/docs/Payables/hooks/usePayableDetails.mdx
@@ -87,7 +87,7 @@ The props for `usePayableDetails` are the same as [`PayableDetails`](./PayableDe
 
 | Name                | Type                                                                 | Description                   |
 | :------------------ | :------------------------------------------------------------------- | :---------------------------- |
-| `selectedVendor`    | `Mercoa.CounterpartyResponse \| undefined`                           | Currently selected vendor.    |
+| `selectedVendor`    | `Mercoa.CounterpartyResponse \| undefined`                           | Now selected vendor.    |
 | `setSelectedVendor` | `Dispatch<SetStateAction<Mercoa.CounterpartyResponse \| undefined>>` | Sets the selected vendor.     |
 | `vendors`           | `Mercoa.CounterpartyResponse[] \| undefined`                         | List of available vendors.    |
 | `vendorsLoading`    | `boolean`                                                            | Whether vendors are loading.  |


### PR DESCRIPTION
- Suggest simple and concise words instead of complex terminology.
  This rule suggests simpler synonyms for complex terminologies in your text to make it more understandable.