### PR TITLE
docs: Suggest simple and concise words or sentences

### DIFF
--- a/docs/pages/docs/Approvals/PolicyEditor.mdx
+++ b/docs/pages/docs/Approvals/PolicyEditor.mdx
@@ -3,11 +3,11 @@ import { ComponentContainer, ComponentCustomizationOptions } from '../../../comp
 
 # Approval Policy Editor
 
-The `<ApprovalPolicies>` component can be used to configure invoice approval policies for an Entity.
+The `<ApprovalPolicies>` part can be used to configure invoice approval policies for an Entity.
 
 ## Customization Options
 
-| Themeable | Variations | Custom Component |
+| Themeable | Variations | Custom Part |
 | :-------: | :--------: | :--------------: |
 |    ✅     |     ❌     |        ❌        |
 

--- a/docs/pages/docs/Architecture.mdx
+++ b/docs/pages/docs/Architecture.mdx
@@ -7,13 +7,13 @@ description: 'Documentation for the Provider + Context model used for handling s
 
 ## Overview
 
-The **New Component Architecture** follows a **Provider + Context model**, where components receive props, pass them into a **custom hook**, and expose processed state, asynchronous data, and event handlers via **React Context**. This ensures **centralized state management, prevents prop drilling, and optimizes re-renders** across the component tree.
+The **New Part Architecture** follows a **Provider + Context model**, where parts receive props, pass them into a **custom hook**, and expose processed state, asynchronous data, and event handlers via **React Context**. This ensures **centralized state management, prevents prop drilling, and optimizes re-renders** across the part tree.
 
-This architecture is applicable to multiple components, providing a consistent approach to handling **data fetching, state management, and event-driven updates**.
+This architecture is applicable to many components, providing a consistent approach to handling **data fetching, state management, and event-driven updates**.
 
 ## Architectural Flow
 
-1. **Parent Component** (e.g., `PayableDetails`)
+1. **Parent Part** (e.g., `PayableDetails`)
 
    - Accepts **query options, configuration, display settings, event handlers, and UI overrides** as props.
    - Passes these to a **custom hook (`usePayableDetails`)** for processing.
@@ -49,13 +49,13 @@ export type PayablesProps = {
 
 - **Query Options (`queryOptions`)**: Specifies parameters required for fetching and filtering data.
 - **Render Customization (`renderCustom`)**: Allows overriding default UI components and behaviors.
-- **Display Options (`displayOptions`)**: Defines structural and positional settings of the component.
+- **Display Options (`displayOptions`)**: Defines structural and positional settings of the part.
 - **Handlers (`handlers`)**: Includes event callbacks for user interactions and lifecycle events.
 - **Configuration (`config`)**: Controls internal logic and functional behaviors.
 
-## Example Component Breakdown
+## Example Part Breakdown
 
-### Parent Component (`PayableDetails`)
+### Parent Part (`PayableDetails`)
 
 Responsible for initializing the provider and rendering child components.
 
@@ -114,7 +114,7 @@ export const usePayableDetailsContext = () => {
 }
 ```
 
-### Child Component (`PayableForm`)
+### Child Part (`PayableForm`)
 
 Consumes data from context and uses it in the UI.
 
@@ -155,4 +155,4 @@ export const PayableForm = () => {
 - **Optimized re-renders**, ensuring components only update when necessary.
 - **Consistent API design** across different components.
 
-This **New Component Architecture** provides a **scalable and maintainable pattern** for managing data and UI logic across components. It ensures a **consistent and efficient approach** to state management while keeping components decoupled from data-fetching logic.
+This **New Part Architecture** provides a **scalable and maintainable pattern** for managing data and UI logic across components. It ensures a **consistent and efficient approach** to state management while keeping components decoupled from data-fetching logic.

--- a/docs/pages/docs/Counterparties/Details.mdx
+++ b/docs/pages/docs/Counterparties/Details.mdx
@@ -4,11 +4,11 @@ import { payerEntity, vendorEntities } from '../../../mockData'
 
 # Counterparty Details
 
-The `<CounterpartyDetails>` component displays details about a counterparty entity.
+The `<CounterpartyDetails>` part displays details about a counterparty entity.
 
 ## Customization Options
 
-| Themeable | Variations | Custom Component |
+| Themeable | Variations | Custom Part |
 | :-------: | :--------: | :--------------: |
 |    ✅     |     ❌     |        ❌        |
 

--- a/docs/pages/docs/Counterparties/Manage.mdx
+++ b/docs/pages/docs/Counterparties/Manage.mdx
@@ -9,7 +9,7 @@ The `<Counterparties>` renders a list of counterparties that can be selected, as
 
 ## Customization Options
 
-| Themeable | Variations | Custom Component |
+| Themeable | Variations | Custom Part |
 | :-------: | :--------: | :--------------: |
 |    ✅     |     ❌     |        ✅        |
 

--- a/docs/pages/docs/Counterparties/Search.mdx
+++ b/docs/pages/docs/Counterparties/Search.mdx
@@ -4,11 +4,11 @@ import { payerEntity, vendorEntities } from '../../../mockData'
 
 # Counterparty Search
 
-The `<CounterpartySearch>` component lets you search for, select, and edit a counterparty, or create a new one.
+The `<CounterpartySearch>` part lets you search for, select, and edit a counterparty, or create a new one.
 
 ## Customization Options
 
-| Themeable | Variations | Custom Component |
+| Themeable | Variations | Custom Part |
 | :-------: | :--------: | :--------------: |
 |    ✅     |     ❌     |        ❌        |
 

--- a/docs/pages/docs/Entity/EmailInbox.mdx
+++ b/docs/pages/docs/Entity/EmailInbox.mdx
@@ -1,15 +1,15 @@
 import { EntityInboxEmail } from '@mercoa/react'
 import { ComponentContainer } from '../../../components/helpers'
 
-# Entity Inbox Email Address
+# Entity Inbox Email Discuss
 
-The `<EntityInboxEmail>` component displays an entity's email inbox address and lets them easily copy it to their clipboard.
+The `<EntityInboxEmail>` part displays an entity's email inbox discuss and lets them easily copy it to their clipboard.
 
-If an entity group token is passed in, this component will render the email address for the entity group unless an entity is selected at the `MercoaSession` level.
+If an entity group token is passed in, this part will render the email discuss for the entity group unless an entity is selected at the `MercoaSession` level.
 
 ## Customization Options
 
-| Themeable | Variations | Custom Component |
+| Themeable | Variations | Custom Part |
 | :-------: | :--------: | :--------------: |
 |    ✅     |     ❌     |        ❌        |
 

--- a/docs/pages/docs/Entity/EmailLogs.mdx
+++ b/docs/pages/docs/Entity/EmailLogs.mdx
@@ -4,11 +4,11 @@ import { ComponentContainer } from '../../../components/helpers'
 
 # Entity Email Logs / Activity
 
-The `<EntityEmailLogs>` component displays emails that have been sent to the entity's email address
+The `<EntityEmailLogs>` part displays emails that have been sent to the entity's email discuss
 
 ## Customization Options
 
-| Themeable | Variations | Custom Component |
+| Themeable | Variations | Custom Part |
 | :-------: | :--------: | :--------------: |
 |    ❌     |     ❌     |        ✅        |
 

--- a/docs/pages/docs/Entity/EntitySelector.mdx
+++ b/docs/pages/docs/Entity/EntitySelector.mdx
@@ -3,11 +3,11 @@ import { ComponentContainer } from '../../../components/helpers'
 
 # Entity Selector
 
-The `<EntitySelector>` component lets you select an entity from a list of entities in an entity group.
+The `<EntitySelector>` part lets you select an entity from a list of entities in an entity group.
 
 ## Customization Options
 
-| Themeable | Variations | Custom Component |
+| Themeable | Variations | Custom Part |
 | :-------: | :--------: | :--------------: |
 |    ✅     |     ❌     |        ❌        |
 

--- a/docs/pages/docs/Entity/Onboarding.mdx
+++ b/docs/pages/docs/Entity/Onboarding.mdx
@@ -4,15 +4,15 @@ import { ComponentContainer } from '../../../components/helpers'
 
 # Entity Onboarding
 
-The `<EntityOnboarding>` component can be used to collect onboarding information from your customers (C2) and their counterparties (C3).
+The `<EntityOnboarding>` part can be used to collect onboarding information from your customers (C2) and their counterparties (C3).
 
 Mercoa will pre-fill any data already captured or provided via API.
 
-Fields displayed on the onboarding component are controlled by your [onboarding configuration](https://mercoa.com/dashboard/developers#customizations). This component can capture [business representatives](https://docs.mercoa.com/concepts/business-representatives), payment details, and let the user accept the Mercoa Terms of Service if those options are enabled.
+Fields displayed on the onboarding part are controlled by your [onboarding configuration](https://mercoa.com/dashboard/developers#customizations). This part can capture [business representatives](https://docs.mercoa.com/concepts/business-representatives), payment details, and let the user accept the Mercoa Terms of Service if those options are enabled.
 
 ## Customization Options
 
-| Themeable | Variations | Custom Component |
+| Themeable | Variations | Custom Part |
 | :-------: | :--------: | :--------------: |
 |    ✅     |     ❌     |        ❌        |
 

--- a/docs/pages/docs/Entity/OnboardingForm.mdx
+++ b/docs/pages/docs/Entity/OnboardingForm.mdx
@@ -4,15 +4,15 @@ import { ComponentContainer } from '../../../components/helpers'
 
 # Entity Onboarding Form
 
-The `<EntityOnboardingForm>` component is the raw form used to collect onboarding information from your customers (C2) and their counterparties (C3).
+The `<EntityOnboardingForm>` part is the raw form used to collect onboarding information from your customers (C2) and their counterparties (C3).
 
-Most of the time, you should use the [`<EntityOnboarding`> component](/Entity/Onboarding), but if you want to process the data before it is sent to Mercoa, you can use this component.
+Most of the time, you should use the [`<EntityOnboarding`> part](/Entity/Onboarding), but if you want to process the data before it is sent to Mercoa, you can use this part.
 
-Fields displayed on the onboarding component are controlled by your [onboarding configuration](https://mercoa.com/dashboard/developers#customizations).
+Fields displayed on the onboarding part are controlled by your [onboarding configuration](https://mercoa.com/dashboard/developers#customizations).
 
 ## Customization Options
 
-| Themeable | Variations | Custom Component |
+| Themeable | Variations | Custom Part |
 | :-------: | :--------: | :--------------: |
 |    ✅     |     ❌     |        ❌        |
 
@@ -23,7 +23,7 @@ Fields displayed on the onboarding component are controlled by your [onboarding 
 | entity             | `Mercoa.EntityResponse`                | ✅       | The entity to onboard                                                                                                               |
 | type               | `"payee"` `"payor"`                    | ✅       | Use `Payee` to onboard a vendor, and `Payor` to onboard a payer                                                                     |
 | onOnboardingSubmit | `((data: OnboardingFormData) => void)` |          | Callback called with all form data when submitted                                                                                   |
-| admin              | `boolean`                              |          | If true, will show all fields as well as additional fields like `isPayor` and `isPayee`. Useful to build internal admin dashboards. |
+| admin              | `boolean`                              |          | If true, will show all fields as well as more fields like `isPayor` and `isPayee`. Useful to build internal admin dashboards. |
 
 ## Examples
 


### PR DESCRIPTION
- Suggest simple and concise words or sentences
  This rule suggests simpler synonyms for complex words in your text to make it more understandable.