### PR TITLE
docs: Suggest using contractions

### DIFF
--- a/docs/pages/docs/Entity/OnboardingForm.mdx
+++ b/docs/pages/docs/Entity/OnboardingForm.mdx
@@ -6,7 +6,7 @@ import { ComponentContainer } from '../../../components/helpers'
 
 The `<EntityOnboardingForm>` component is the raw form used to collect onboarding information from your customers (C2) and their counterparties (C3).
 
-Most of the time, you should use the [`<EntityOnboarding`> component](/Entity/Onboarding), but if you want to process the data before it is sent to Mercoa, you can use this component.
+Most of the time, you should use the [`<EntityOnboarding`> component](/Entity/Onboarding), but if you want to process the data before it's sent to Mercoa, you can use this component.
 
 Fields displayed on the onboarding component are controlled by your [onboarding configuration](https://mercoa.com/dashboard/developers#customizations).
 

--- a/docs/pages/docs/Entity/RepresentativeForm.mdx
+++ b/docs/pages/docs/Entity/RepresentativeForm.mdx
@@ -6,7 +6,7 @@ import { ComponentContainer } from '../../../components/helpers'
 
 The `<RepresentativeOnboardingForm>` component is the raw form used to collect new representative information.
 
-Most of the time, you should use the [`<EntityOnboarding`> component](/Entity/Onboarding), but if you want to process the data before it is sent to Mercoa, you can use this component.
+Most of the time, you should use the [`<EntityOnboarding`> component](/Entity/Onboarding), but if you want to process the data before it's sent to Mercoa, you can use this component.
 
 ## Customization Options
 

--- a/docs/pages/docs/Metrics.mdx
+++ b/docs/pages/docs/Metrics.mdx
@@ -8,7 +8,7 @@ import { Bar, BarChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recha
 
 The `<InvoiceMetrics>` component can be display metrics and graphs about invoices, like total count, average amount, group by date, etc.
 
-While Mercoa does not ship charts and graphs out of the box, this component can be combined with your graphing library of choice to generate charts and graphs!
+While Mercoa doesn't ship charts and graphs out of the box, this component can be combined with your graphing library of choice to generate charts and graphs!
 
 ## Customization Options
 
@@ -30,7 +30,7 @@ While Mercoa does not ship charts and graphs out of the box, this component can 
 
 
 <Callout type="warning" emoji="⚠️">
-  `excludePayables` and `excludeReceivables` cannot both be true or false. If neither is passed, `excludeReceivables` is set to `true`
+  `excludePayables` and `excludeReceivables` can't both be true or false. If neither is passed, `excludeReceivables` is set to `true`
 </Callout>
 
 ## Examples

--- a/docs/pages/docs/Migration.mdx
+++ b/docs/pages/docs/Migration.mdx
@@ -7,7 +7,7 @@ description: 'Guide for migrating from legacy implementations to the standardize
 
 ## Overview
 
-If your current infrastructure does not follow a structured **Provider + Context** model, migrating to this standardized architecture will improve **maintainability, reusability, and performance**. This document provides a structured approach to refactoring existing implementations to align with the new component model.
+If your current infrastructure doesn't follow a structured **Provider + Context** model, migrating to this standardized architecture will improve **maintainability, reusability, and performance**. This document provides a structured approach to refactoring existing implementations to align with the new component model.
 
 ## Migration Steps
 

--- a/docs/pages/docs/Payables/hooks/usePayableDetails.mdx
+++ b/docs/pages/docs/Payables/hooks/usePayableDetails.mdx
@@ -9,7 +9,7 @@ The `usePayableDetails` hook is used inside children of the `<PayableDetails>` c
 
 ## Props
 
-The props for `usePayableDetails` are the same as [`PayableDetails`](./PayableDetails), as it is meant to be used within its context.
+The props for `usePayableDetails` are the same as [`PayableDetails`](./PayableDetails), as it's meant to be used within its context.
 
 ## Return Type
 

--- a/docs/pages/docs/Payables/hooks/usePayables.mdx
+++ b/docs/pages/docs/Payables/hooks/usePayables.mdx
@@ -9,7 +9,7 @@ The `usePayables` hook is used inside children of the `<Payables>` component. It
 
 ## Props
 
-The props for `usePayables` are the same as [`Payables`](./Payables), as it is meant to be used within its context.
+The props for `usePayables` are the same as [`Payables`](./Payables), as it's meant to be used within its context.
 
 ## Return Type
 

--- a/docs/pages/docs/Receivables/hooks/useReceivableDetails.mdx
+++ b/docs/pages/docs/Receivables/hooks/useReceivableDetails.mdx
@@ -9,7 +9,7 @@ The `useReceivableDetails` hook is used inside children of the `<ReceivableDetai
 
 ## Props
 
-The props for `useReceivableDetails` are the same as [`ReceivableDetails`](./ReceivableDetails), as it is meant to be used within its context.
+The props for `useReceivableDetails` are the same as [`ReceivableDetails`](./ReceivableDetails), as it's meant to be used within its context.
 
 ## Return Type
 

--- a/docs/pages/docs/Receivables/hooks/useReceivables.mdx
+++ b/docs/pages/docs/Receivables/hooks/useReceivables.mdx
@@ -9,7 +9,7 @@ The `useReceivables` hook is used inside children of the `<Receivables>` compone
 
 ## Props
 
-The props for `useReceivables` are the same as [`Receivables`](./Receivables), as it is meant to be used within its context.
+The props for `useReceivables` are the same as [`Receivables`](./Receivables), as it's meant to be used within its context.
 
 ## Return Type
 

--- a/docs/pages/docs/Session.mdx
+++ b/docs/pages/docs/Session.mdx
@@ -9,7 +9,7 @@ The Mercoa React component library uses a [React Context](https://legacy.reactjs
 The `<MercoaSession>` requires a [valid JWT token](https://docs.mercoa.com/api-reference/entity/user/get-token) to be passed in to authenticate the [Entity](https://docs.mercoa.com/concepts/entities) and [User](https://docs.mercoa.com/concepts/users).
 
 <Callout type="error" emoji="⚠️">
-  Do not use your API key as the token! The API key is for backend use only and should never be exposed.
+  Don't use your API key as the token! The API key is for backend use only and should never be exposed.
 </Callout>
 
 Once this context is established, any React Component inside the context can use the `useMercoaSession` hook to access helper methods and cached data, making it easier to develop frontends with Mercoa.

--- a/docs/pages/docs/index.mdx
+++ b/docs/pages/docs/index.mdx
@@ -26,7 +26,7 @@ This context has many useful helper methods and cached data you can learn more a
 The `<MercoaSession>` requires a [valid JWT token](https://docs.mercoa.com/api-reference/entity/user/get-token) to be passed in to authenticate the [Entity](https://docs.mercoa.com/concepts/entities) and [User](https://docs.mercoa.com/concepts/users).
 
 <Callout type="error" emoji="⚠️">
-  Do not use your API key as the token! The API key is for backend use only and should never be exposed.
+  Don't use your API key as the token! The API key is for backend use only and should never be exposed.
 </Callout>
 
 ### Basic Usage


### PR DESCRIPTION
- Suggest using contractions
  This rule flags phrases that can be made more casual and brief by using contractions. For instance, it replaces 'do not' with 'don't', and 'is not' with 'isn't', and more.