### PR TITLE
docs: Avoid language that defines people by their disability

### DIFF
--- a/docs/pages/docs/Legacy/Payables/Table.mdx
+++ b/docs/pages/docs/Legacy/Payables/Table.mdx
@@ -341,14 +341,14 @@ type PayablesTableChildrenProps = {
         <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: '5px' }}>
           <button
             style={{ padding: '5px', border: '1px solid #eee', color: hasPrevious ? '#000' : '#ccc' }}
-            disabled={!hasPrevious}
+            enabled={!hasPrevious}
             onClick={getPrevious}
           >
             Previous
           </button>
           <button
             style={{ padding: '5px', border: '1px solid #eee', color: hasNext ? '#000' : '#ccc' }}
-            disabled={!hasNext}
+            enabled={hasNext}
             onClick={getNext}
           >
             Next

--- a/docs/pages/docs/Receivables/components/ReceivableDetails.mdx
+++ b/docs/pages/docs/Receivables/components/ReceivableDetails.mdx
@@ -49,7 +49,7 @@ The `<ReceivableDetails>` component is used to let users create and manage recei
 | Name                      | Type                    | Required | Description                                               |
 | ------------------------- | ----------------------- | -------- | --------------------------------------------------------- |
 | `supportedCurrencies`     | `Mercoa.CurrencyCode[]` |          | List of currencies supported in this component.           |
-| `disableCustomerCreation` | `boolean`               |          | Whether customer creation should be disabled in the form. |
+| `disableCustomerCreation` | `boolean`               |          | Whether customer creation should be turned off in the form. |
 
 ---
 


### PR DESCRIPTION
- Avoid language that defines people by their disability
  This rule prompts you to maintain the principle of using inclusive language in your interaction with and about people with disabilities. It flags certain language patterns that stereotype or reduce people to their disabilities. Such patterns include 'a victim of', 'handicapped', 'suffers from', and similar.