### PR TITLE
docs: Prefer English terms over Latin abbreviations

### DIFF
--- a/docs/pages/docs/Architecture.mdx
+++ b/docs/pages/docs/Architecture.mdx
@@ -13,7 +13,7 @@ This architecture is applicable to multiple components, providing a consistent a
 
 ## Architectural Flow
 
-1. **Parent Component** (e.g., `PayableDetails`)
+1. **Parent Component** (for example, `PayableDetails`)
 
    - Accepts **query options, configuration, display settings, event handlers, and UI overrides** as props.
    - Passes these to a **custom hook (`usePayableDetails`)** for processing.

--- a/docs/pages/docs/Migration.mdx
+++ b/docs/pages/docs/Migration.mdx
@@ -13,7 +13,7 @@ If your current infrastructure does not follow a structured **Provider + Context
 
 ### 1. Adopt the Standardized Props Structure
 
-Instead of passing ad-hoc props to each component, follow a consistent structure for passing **query options, handlers, configuration, and UI settings**.
+Instead of passing if needed props to each component, follow a consistent structure for passing **query options, handlers, configuration, and UI settings**.
 
 #### **Before (Inconsistent Props Across Components)**
 


### PR DESCRIPTION
- Prefer English terms over Latin abbreviations
  This rule mandates the use of English terms instead of Latin abbreviations in your content. If Latin abbreviations like 'e.g.' and 'i.e.' are used, they will be flagged as errors. The system will suggest replacements with 'for example' and 'that is' respectively. This improves readability and comprehension for all users.