### PR TITLE
docs: Ensure a single space between words

### DIFF
--- a/docs/pages/docs/Payables/hooks/usePayableDetails.mdx
+++ b/docs/pages/docs/Payables/hooks/usePayableDetails.mdx
@@ -89,7 +89,7 @@ The props for `usePayableDetails` are the same as [`PayableDetails`](./PayableDe
 | :------------------ | :------------------------------------------------------------------- | :---------------------------- |
 | `selectedVendor`    | `Mercoa.CounterpartyResponse \| undefined`                           | Currently selected vendor.    |
 | `setSelectedVendor` | `Dispatch<SetStateAction<Mercoa.CounterpartyResponse \| undefined>>` | Sets the selected vendor.     |
-| `vendors`           | `Mercoa.CounterpartyResponse[] \| undefined`                         | List of available vendors.    |
+| `vendors`           | `Mercoa.CounterpartyResponse[] | undefined`                         | List of available vendors. |
 | `vendorsLoading`    | `boolean`                                                            | Whether vendors are loading.  |
 | `vendorSearch`      | `string`                                                             | Vendor search query.          |
 | `setVendorSearch`   | `(search: string) => void`                                           | Sets the vendor search query. |


### PR DESCRIPTION
- Ensure a single space between words
  This rule verifies the use of one space between words, ensuring optimal readability. It flags an error if two or more spaces are found between words or if there is no space following a sentence punctuation mark.