### PR TITLE
docs: Avoid end punctuation in headings

### DIFF
--- a/docs/pages/docs/Architecture.mdx
+++ b/docs/pages/docs/Architecture.mdx
@@ -45,7 +45,7 @@ export type PayablesProps = {
 }
 ```
 
-### Explanation of Prop Categories:
+### Explanation of Prop Categories
 
 - **Query Options (`queryOptions`)**: Specifies parameters required for fetching and filtering data.
 - **Render Customization (`renderCustom`)**: Allows overriding default UI components and behaviors.


### PR DESCRIPTION
- Avoid end punctuation in headings
  This rule warns writers if they use any end punctuation in headings and suggests an automatic edit to remove. End punctuation is not recommended in headings.