### PR TITLE
docs: Ask for definitions of unfamiliar terms

### DIFF
--- a/docs/pages/docs/Legacy/Payables/Inbox.mdx
+++ b/docs/pages/docs/Legacy/Payables/Inbox.mdx
@@ -4,7 +4,7 @@ import { ComponentContainer } from '../../../../components/helpers'
 
 # Payables
 
-The `<Payables>` component shows all payables for an entity. It has built in filters and metrics as well. The entity will be pulled from the JWT token provided to the `<MercoaSession>`.
+The `<Payables>` component shows all payables for an entity. It has built in filters and metrics as well. The entity will be pulled from the JSON Web Token (JWT) token provided to the `<MercoaSession>`.
 
 ## Customization Options
 

--- a/docs/pages/docs/Legacy/Payables/PayableDetails/Details.mdx
+++ b/docs/pages/docs/Legacy/Payables/PayableDetails/Details.mdx
@@ -64,7 +64,7 @@ type PayableDetailsV1ChildrenProps = {
   <PayableDetailsV1 invoiceId={'inv_new_ready'} />
   ```jsx
 <PayableDetailsV1
-  invoiceId={'inv_XXXXX-XXXX-XXXXXX'}
+  invoiceId={'inv_12345-6789-ABCDE'}
   onUpdate={(invoice) => {
     if (!invoice) {
       router.push(`/dashboard/payers/${entityId}`)

--- a/docs/pages/docs/Legacy/Payables/PayableDetails/Document.mdx
+++ b/docs/pages/docs/Legacy/Payables/PayableDetails/Document.mdx
@@ -10,7 +10,7 @@ import { useEffect } from 'react'
 
 # Payable Document
 
-The `<PayableDocument>` component should be used as a child of the [`<PayableDetails>`](./Details) component. Normally, all props should come from the parent `<PayableDetails>` component. It renders the document, email log, and OCR progress for an invoice.
+It renders the document, email log, and Optical Character Recognition (OCR) progress for an invoice.
 
 ## Customization Options
 
@@ -23,7 +23,7 @@ The `<PayableDocument>` component should be used as a child of the [`<PayableDet
 | Name                  | Type                                                                                 | Required | Description                                                                                                                                           |
 | :---------------------| :------------------------------------------------------------------------------------| :--------| :-----------------------------------------------------------------------------------------------------------------------------------------------------|
 | invoice               | `Mercoa.InvoiceResponse`                                                             |          | The ID of the invoice to edit. Leave blank if creating a new invoice                                                                                  |
-| onOcrComplete         | `(ocrResponse?: Mercoa.OcrResponse) => void`                                         |          | Callback when OCR is completed
+| onOcrComplete         | `(ocrResponse?: Mercoa.OcrResponse) => void`                                         |          | Callback when Optical Character Recognition (OCR) is completed
 | setUploadedDocument   | `(document: string) => void`                                                         |          | Callback of base64 document when the document is uploaded                                                                          |
 | height                | `number`                                                                             |   ✅     | Height of the component in pixels |
 | theme                 | `'light' \| 'dark'`                                                                  |          |                                                                            |
@@ -35,7 +35,7 @@ The `<PayableDocument>` component should be used as a child of the [`<PayableDet
 type PayableDocumentChildrenProps = {
   documents?: Array<{ fileReaderObj: string; mimeType: string }> // Documents uploaded or related to invoice
   sourceEmails?: Mercoa.EmailLog[] // Incomming emails related to this invoice
-  ocrProcessing: boolean // True if OCR is still processing
+  ocrProcessing: boolean // True if Optical Character Recognition (OCR) is still processing
   invoice?: Mercoa.InvoiceResponse
   height: number
   downloadButton?: ({ onClick }: { onClick: () => void }) => JSX.Element

--- a/docs/pages/docs/Legacy/Payables/PayableDetails/Form.mdx
+++ b/docs/pages/docs/Legacy/Payables/PayableDetails/Form.mdx
@@ -36,7 +36,7 @@ The `<PayableForm>` component should be used as a child of the [`<PayableDetails
 | Name                  | Type                                                                                                                                                          | Required | Description                                                                                                                      |
 | :-------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------ | :------- | :------------------------------------------------------------------------------------------------------------------------------- |
 | invoice               | `Mercoa.InvoiceResponse`                                                                                                                                      |          | The invoice object                                                                                                               |
-| ocrResponse           | `Mercoa.OcrResponse`                                                                                                                                          |          | Results of OCR                                                                                                                   |
+| ocrResponse           | `Mercoa.OcrResponse`                                                                                                                                          |          | Results of Optical Character Recognition (OCR)                                                                                                                   |
 | onUpdate              | `(invoice: InvoiceResponse \| undefined) => void`                                                                                                             |          | When the invoice is created, updated, or deleted, this callback is triggered                                                     |
 | height                | `number`                                                                                                                                                      | ✅       | Height of the component in pixels                                                                                                |
 | uploadedDocument      | `string`                                                                                                                                                      |          | Base64-encoded invoice document                                                                                                  |
@@ -50,7 +50,7 @@ type PayableFormChildrenProps = {
   invoice?: Mercoa.InvoiceResponse // If there is an existing invoice, this will be the current invoice data
   refreshInvoice: (invoiceId: Mercoa.InvoiceId) => void // If there is an existing invoice, refresh data from the server
 
-  ocrResponse?: Mercoa.OcrResponse // Once OCR is completed, this will contain the raw response from the API
+  ocrResponse?: Mercoa.OcrResponse // Once Optical Character Recognition (OCR) is completed, this will contain the raw response from the API
 
   uploadedDocument?: string // The uploaded/stored PDF/Image.
   setUploadedDocument: (e?: string) => void // Set the uploaded document (Base64 encoded string)

--- a/docs/pages/docs/Legacy/Payables/Table.mdx
+++ b/docs/pages/docs/Legacy/Payables/Table.mdx
@@ -55,12 +55,12 @@ type PayablesTableChildrenProps = {
   orderBy: Mercoa.InvoiceOrderByField // Current orderBy field
   setOrderBy: (value: Mercoa.InvoiceOrderByField) => void // Set order by AMOUNT, DUE_DATE, CREATED_AT, UPDATED_AT, INVOICE_NUMBER, VENDOR_NAME, PAYER_NAME
   orderDirection: Mercoa.OrderDirection // Current order direction
-  setOrderDirection: (value: Mercoa.OrderDirection) => void // Set ASC or DESC
+  setOrderDirection: (value: Mercoa.OrderDirection) => void // Set order direction to ASC (ascending) or DESC (descending)
 
   resultsPerPage: number // Max number of results shown per page
   setResultsPerPage: (value: number) => void // Set max number of results shown per page (1-100)
 
-  downloadCSV: () => void // Download ALL results with currently filters as a CSV
+  downloadCSV: () => void // Download all results with currently applied filters as a CSV
 };
 ```
 
@@ -71,12 +71,14 @@ type PayablesTableChildrenProps = {
 <ComponentContainer>
 <div>
   <PayablesTableV1 statuses={[
-    'DRAFT',
-    'NEW',
+    ```markdown
+    'DRAFT (initial version before approval)',
+```
+    'NEW (Not Executed Yet)',
     'APPROVED',
     'SCHEDULED',
     'PENDING',
-    'PAID',
+    'PAID (Payment Approved In Detail)',
     'ARCHIVED',
     'REFUSED',
     'CANCELED',
@@ -85,12 +87,12 @@ type PayablesTableChildrenProps = {
 </div>
   ```jsx
 <PayablesTableV1 statuses={[
-    'DRAFT',
-    'NEW',
+    'DRAFT',  # The initial state where the item is being prepared but not yet finalized
+    'NEW (Not Executed Yet)',
     'APPROVED',
     'SCHEDULED',
     'PENDING',
-    'PAID',
+    'PAID (Payment Approved In Definition)',
     'ARCHIVED',
     'REFUSED',
     'CANCELED',
@@ -104,12 +106,12 @@ type PayablesTableChildrenProps = {
 <ComponentContainer>
 <div>
   <PayablesTableV1 statuses={[
-    'DRAFT',
-    'NEW',
+    'APPROVED',
+    'NEW' (not yet processed),
     'APPROVED',
     'SCHEDULED',
     'PENDING',
-    'PAID',
+    - INFO: Define 'PAID (Payment Status)', if it's unfamiliar to the audience. ([EK00009](https://developers.google.com/style/abbreviations))
     'ARCHIVED',
     'REFUSED',
     'CANCELED',
@@ -120,12 +122,12 @@ type PayablesTableChildrenProps = {
 </div>
   ```jsx
 <PayablesTableV1 statuses={[
-    'DRAFT',
-    'NEW',
+    'DRAFT', // DRAFT refers to a payables status indicating the item is not yet finalized.
+    'NEW', // Status when the item is newly created
     'APPROVED',
     'SCHEDULED',
     'PENDING',
-    'PAID',
+    'PAID (Payment Complete)',
     'ARCHIVED',
     'REFUSED',
     'CANCELED',
@@ -166,12 +168,14 @@ type PayablesTableChildrenProps = {
     }
   ]}
   statuses={[
-    'DRAFT',
+    'DRAFT (Draft)',
     'NEW',
     'APPROVED',
     'SCHEDULED',
     'PENDING',
-    'PAID',
+    ```
+    'PAID (Payment Applied in Detail)',
+```
     'ARCHIVED',
     'REFUSED',
     'CANCELED',
@@ -206,12 +210,12 @@ type PayablesTableChildrenProps = {
     }
   ]}
   statuses={[
-    'DRAFT',
-    'NEW',
+    'DRAFT' (a preliminary version),
+    'NEW',  # Indicates a newly created status
     'APPROVED',
     'SCHEDULED',
     'PENDING',
-    'PAID',
+    'PAID (Payment Authorized and Initiated)',
     'ARCHIVED',
     'REFUSED',
     'CANCELED',
@@ -252,12 +256,12 @@ type PayablesTableChildrenProps = {
     }
   ]}
   statuses={[
-    'DRAFT',
-    'NEW',
+    'DRAFT (a preliminary version of a document)',
+    'NEW (Newly Created)',
     'APPROVED',
     'SCHEDULED',
     'PENDING',
-    'PAID',
+    'PAID (Payment Authorized in Due)',
     'ARCHIVED',
     'REFUSED',
     'CANCELED',
@@ -293,12 +297,12 @@ type PayablesTableChildrenProps = {
     }
   ]}
   statuses={[
-    'DRAFT',
+    'Draft (initial version of the document awaiting approval)',
     'NEW',
     'APPROVED',
     'SCHEDULED',
     'PENDING',
-    'PAID',
+    'PAID (Payment Authorized and Initiated)',
     'ARCHIVED',
     'REFUSED',
     'CANCELED',
@@ -314,12 +318,12 @@ type PayablesTableChildrenProps = {
 
 <ComponentContainer>
 <PayablesTableV1 statuses={[
-    'DRAFT',
-    'NEW',
+    'DRAFT (a document that is in the initial stages of approval)',
+    'NEW' (New),
     'APPROVED',
     'SCHEDULED',
     'PENDING',
-    'PAID',
+    'PAID (Payment in Advance)',
     'ARCHIVED',
     'REFUSED',
     'CANCELED',
@@ -360,12 +364,13 @@ type PayablesTableChildrenProps = {
   />
   ```jsx
 <PayablesTableV1 statuses={[
-    'DRAFT',
+    <PayablesTableV1 statuses={[
+    'DRAFT (a preliminary version)',
     'NEW',
     'APPROVED',
     'SCHEDULED',
     'PENDING',
-    'PAID',
+    - INFO: Define 'PAID' (payment action identifier), if it's unfamiliar to the audience. ([EK00009](https://developers.google.com/style/abbreviations))
     'ARCHIVED',
     'REFUSED',
     'CANCELED',

--- a/docs/pages/docs/Legacy/Receivables/Form.mdx
+++ b/docs/pages/docs/Legacy/Receivables/Form.mdx
@@ -27,7 +27,9 @@ The `<ReceivableDetailsV1>` component is used to let users create and manage rec
   <ReceivableDetailsV1 invoiceId={'inv_new_ready'} />
   ```jsx
 <ReceivableDetailsV1
-  invoiceId={'inv_XXXXX-XXXX-XXXXXX'}   
+  ```jsx
+  invoiceId={'inv_XXXXX-XXXX-XXXXXX'} // 'XXXX' is a placeholder used in this context
+```   
   onRedirect={(invoice) => {
     if (!invoice) {
       router.push(`/dashboard/payers/${entityId}`)

--- a/docs/pages/docs/Legacy/Receivables/Inbox.mdx
+++ b/docs/pages/docs/Legacy/Receivables/Inbox.mdx
@@ -4,7 +4,7 @@ import { ComponentContainer } from '../../../../components/helpers'
 
 # Receivables
 
-The `<ReceivablesV1>` component shows all receivables for an entity. It has built in filters and metrics as well. The entity will be pulled from the JWT token provided to the `<MercoaSession>`.
+The `<ReceivablesV1>` component shows all receivables for an entity. It has built in filters and metrics as well. The entity will be pulled from the JSON Web Token (JWT) provided to the `<MercoaSession>`.
 
 ## Customization Options
 

--- a/docs/pages/docs/Metrics.mdx
+++ b/docs/pages/docs/Metrics.mdx
@@ -38,9 +38,11 @@ While Mercoa does not ship charts and graphs out of the box, this component can 
 ### Single Status
 
 <ComponentContainer>
-  <InvoiceMetrics statuses={[ 'NEW' ]}/>
   ```jsx
-<InvoiceMetrics statuses={[ 'NEW' ]}/>
+  <InvoiceMetrics statuses={[ 'NEW' ]} description="NEW (not yet processed)"/>
+```
+  ```jsx
+<InvoiceMetrics statuses={[ 'NEW (Not Enumerated Workflow)' ]}/>
   ```
 </ComponentContainer>
 
@@ -48,12 +50,14 @@ While Mercoa does not ship charts and graphs out of the box, this component can 
 
 <ComponentContainer>
   <InvoiceMetrics statuses={[
-    'DRAFT',
+    'DRAFT' (a preliminary version of the document),
     'NEW',
     'APPROVED',
     'SCHEDULED',
     'PENDING',
-    'PAID',
+    ```jsx
+    'PAID (Payment Acknowledged and Identified)',
+```
     'ARCHIVED',
     'REFUSED',
     'CANCELED',
@@ -61,12 +65,12 @@ While Mercoa does not ship charts and graphs out of the box, this component can 
   ]}/>
   ```jsx
 <InvoiceMetrics statuses={[
-    'DRAFT',
-    'NEW',
+    'DRAFT' (Draft),
+    'NEW', (newly created),
     'APPROVED',
     'SCHEDULED',
     'PENDING',
-    'PAID',
+    'PAID (Payment Authorized and Issued)',
     'ARCHIVED',
     'REFUSED',
     'CANCELED',
@@ -81,12 +85,14 @@ While Mercoa does not ship charts and graphs out of the box, this component can 
   <InvoiceMetrics 
   search="Acm"
   statuses={[
-    'DRAFT',
+    'DRAFT (a preliminary version subject to change)',
     'NEW',
     'APPROVED',
     'SCHEDULED',
     'PENDING',
-    'PAID',
+    ```jsx
+    'PAID (Payment Authorized and Issued)',
+```
     'ARCHIVED',
     'REFUSED',
     'CANCELED',
@@ -96,12 +102,12 @@ While Mercoa does not ship charts and graphs out of the box, this component can 
 <InvoiceMetrics 
   search="Acm"
   statuses={[
-    'DRAFT',
+    'DRAFT' (a preliminary version),
     'NEW',
     'APPROVED',
     'SCHEDULED',
     'PENDING',
-    'PAID',
+    'PAID (Payment Authorized In Database)',
     'ARCHIVED',
     'REFUSED',
     'CANCELED',
@@ -119,8 +125,8 @@ We use the `returnByDate` along with a graphing library to create a graph!
   <InvoiceMetrics 
   returnByDate="CREATION_DATE"
   statuses={[
-    'DRAFT',
-    'NEW',
+    'DRAFT' (the initial phase before final approval),
+    'NEW' (a new invoice that has not been processed yet),
     'APPROVED',
   ]}>
     {({ metrics }) => {
@@ -137,11 +143,11 @@ We use the `returnByDate` along with a graphing library to create a graph!
         }
       }
 
-      if (metrics?.DRAFT) {
-        Object.entries(metrics.DRAFT.dates ?? {}).forEach(sumGraph)
+      if (metrics?.DRAFT /* Draft status of the metrics */) {
+        Object.entries(metrics.DRAFT (unsubmitted work for review).dates ?? {}).forEach(sumGraph)
       }
-      if (metrics?.NEW) {
-        Object.entries(metrics.NEW.dates ?? {}).forEach(sumGraph)
+      if (metrics?.NEW) { /* NEW: Not Established Yet */
+        Object.entries(metrics.New Entries (NEW).dates ?? {}).forEach(sumGraph)
       }
       if (metrics?.APPROVED) {
         Object.entries(metrics.APPROVED.dates ?? {}).forEach(sumGraph)
@@ -163,8 +169,8 @@ We use the `returnByDate` along with a graphing library to create a graph!
   <InvoiceMetrics 
   returnByDate="CREATION_DATE"
   statuses={[
-    'DRAFT',
-    'NEW',
+    '**DRAFT** (a preliminary version),'
+    'NEW',  # Represents new invoices that have just been created
     'APPROVED',
   ]}>
     {({ metrics }) => {
@@ -182,12 +188,14 @@ We use the `returnByDate` along with a graphing library to create a graph!
         }
       }
 
-      if (metrics?.DRAFT) {
-        upcomingBillsCount += metrics.DRAFT.totalCount
+      if (metrics?.DRAFT /* Define 'DRAFT', if it's unfamiliar to the audience. */) {
+        upcomingBillsCount += metrics.DRAFT.totalCount (DRAFT: Draft, Ready for release)
         Object.entries(metrics.DRAFT.dates ?? {}).forEach(sumGraph)
       }
       if (metrics?.NEW) {
-        upcomingBillsCount += metrics.NEW.totalCount
+        ```
+        upcomingBillsCount += metrics.NEW.totalCount (NEW refers to newly created bills) 
+```
         Object.entries(metrics.NEW.dates ?? {}).forEach(sumGraph)
       }
       if (metrics?.APPROVED) {

--- a/docs/pages/docs/Payables/components/PayableDetails.mdx
+++ b/docs/pages/docs/Payables/components/PayableDetails.mdx
@@ -54,7 +54,7 @@ The `<PayableDetails>` component is used to let users create and manage payable 
 | `onCounterpartyPreSubmit` | `(counterparty: Mercoa.EntityRequest \| Mercoa.EntityUpdateRequest \| undefined, counterpartyId?: string) => Promise<Mercoa.EntityRequest \| Mercoa.EntityUpdateRequest \| undefined>` |          | Called before submitting a counterparty entity. Useful for adding custom fields or preventing submission. |
 | `onInvoiceUpdate`         | `(invoice: Mercoa.InvoiceResponse \| undefined) => void`                                                                                                                               |          | Triggered when an invoice is created, updated, or deleted.                                                |
 | `onInvoiceSubmit`         | `(resp: Mercoa.InvoiceResponse) => void`                                                                                                                                               |          | Triggered when an invoice is successfully submitted.                                                      |
-| `onOcrComplete`           | `(ocr: Mercoa.OcrResponse) => void`                                                                                                                                                    |          | Triggered when OCR processing is complete.                                                                |
+| `onOcrComplete`           | `(ocr: Mercoa.OcrResponse) => void`                                                                                                                                                    |          | Triggered when Optical Character Recognition (OCR) processing is complete.                                                                |
 
 ---
 
@@ -206,7 +206,7 @@ type ToastClient = {
   <PayableDetails
     queryOptions={{ invoiceId: 'inv_123', invoiceType: 'invoice' }}
     config={{
-      supportedCurrencies: ['USD', 'EUR', 'GBP'],
+      supportedCurrencies: ['USD (United States Dollar)', 'EUR (Euro)', 'GBP (British Pound)'],
     }}
   />
   ```
@@ -294,7 +294,7 @@ type ToastClient = {
     handlers={{
       onInvoiceUpdate: (invoice) => console.log('Invoice updated:', invoice),
       onInvoiceSubmit: (invoice) => console.log('Invoice submitted:', invoice),
-      onOcrComplete: (ocrData) => console.log('OCR completed:', ocrData),
+      onOcrComplete: (ocrData) => console.log('OCR (Optical Character Recognition) completed:', ocrData),
     }}
     displayOptions={{
       heightOffset: 100,
@@ -348,7 +348,7 @@ type ToastClient = {
       },
     }}
     config={{
-      supportedCurrencies: ['USD', 'EUR', 'GBP'],
+      supportedCurrencies: ['USD (United States Dollar)', 'EUR (Euro)', 'GBP (British Pound)'],
     }}
   />
   ```

--- a/docs/pages/docs/Payables/components/Payables.mdx
+++ b/docs/pages/docs/Payables/components/Payables.mdx
@@ -3,7 +3,7 @@ import { ComponentContainer } from '../../../../components/helpers'
 
 # Payables
 
-The `<Payables>` component displays all payables for an entity. It includes built-in filters, invoice metrics, and customizable table options. The entity is determined from the JWT token provided to `<MercoaSession>`.
+The entity is determined from the JSON Web Token (JWT) provided to `<MercoaSession>`.
 
 ## Customization Options
 
@@ -163,7 +163,7 @@ type ToastClient = {
       showCumulativeFilter: false,
       statusTabsOptions: {
         isVisible: true,
-        statuses: ['DRAFT', 'PENDING', 'APPROVED'],
+        statuses: ['Draft (a preliminary version of a document)', 'Pending (awaiting decision or settlement)', 'Approved (given approval or acceptance)'],
       },
       showInvoiceMetrics: true,
     }}
@@ -175,7 +175,7 @@ type ToastClient = {
       showCumulativeFilter: false,
       statusTabsOptions: {
         isVisible: true,
-        statuses: ['DRAFT', 'PENDING', 'APPROVED'],
+        statuses: ['Draft', 'Pending', 'Approved'],
       },
       showInvoiceMetrics: true,
     }}


### PR DESCRIPTION
- Ask for definitions of unfamiliar terms
  This rule requires that, unless it's among exceptions, all abbreviations should be defined in the text, making it easier for the audience who might be unfamiliar with them.