### PR TITLE
docs: Place commas and periods inside quotation marks

### DIFF
--- a/docs/pages/docs/Entity/EmailInbox.mdx
+++ b/docs/pages/docs/Entity/EmailInbox.mdx
@@ -17,8 +17,8 @@ If an entity group token is passed in, this component will render the email addr
 
 | Name   | Type              | Required | Description                       |
 | :----- | :---------------- | :------- | :-------------------------------- |
-| layout | `"left", "right"` |          | Which side to place the copy icon |
-| theme  | `"dark", "light"` |          | Light or dark theme               |
+| layout | `"left," "right"` |          | Which side to place the copy icon |
+| theme  | `"dark," "light"` |          | Light or dark theme               |
 
 ## Examples
 


### PR DESCRIPTION
- Place commas and periods inside quotation marks
  This rule enforces that commas and periods are placed inside quotation marks