### PR TITLE
Make approver user lists searchable; release 0.1.22

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mercoa/react",
   "description": "Mercoa React Component Library",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "author": "Sandeep Dinesh <sandeep@mercoa.com>",
   "license": "MIT",
   "repository": {

--- a/src/components/generics.tsx
+++ b/src/components/generics.tsx
@@ -762,6 +762,52 @@ export function StatCard({
   )
 }
 
+/**
+ * Filters combobox options against the search query. Matches on the primary display field and on
+ * any secondary display field (e.g. a user's email), so anything visible in the list is searchable.
+ */
+export function filterComboboxOptions<T extends { value: any }>({
+  options,
+  query,
+  displayIndex,
+  secondaryDisplayIndex,
+}: {
+  options: T[]
+  query: string
+  displayIndex?: string
+  secondaryDisplayIndex?: string | string[]
+}): T[] {
+  const lowerQuery = query.toLowerCase()
+  const secondaryIndexes = secondaryDisplayIndex
+    ? Array.isArray(secondaryDisplayIndex)
+      ? secondaryDisplayIndex
+      : [secondaryDisplayIndex]
+    : []
+
+  return options.filter((option) => {
+    const searchableFields: any[] = [
+      displayIndex ? option.value?.[displayIndex] : option.value,
+      ...secondaryIndexes.map((index) => option.value?.[index]),
+    ]
+    return searchableFields.some((field) => {
+      if (Array.isArray(field)) return field.join(' ').toLowerCase().includes(lowerQuery)
+      if (typeof field === 'string') return field.toLowerCase().includes(lowerQuery)
+      if (typeof field === 'number') return String(field).includes(lowerQuery)
+      return false
+    })
+  })
+}
+
+/** Fires `onOpen` on the closed -> open transition of a combobox dropdown. Renders nothing. */
+function ClearSearchOnOpen({ open, onOpen }: { open: boolean; onOpen: () => void }) {
+  const wasOpen = useRef(open)
+  useEffect(() => {
+    if (open && !wasOpen.current) onOpen()
+    wasOpen.current = open
+  })
+  return null
+}
+
 export function MercoaCombobox({
   onChange,
   onRawChange,
@@ -842,14 +888,32 @@ export function MercoaCombobox({
     }
   }, [query, freeText])
 
+  // Multi-select pill comboboxes render the selection as pills instead of text, so there is no
+  // visible field to type into. Show an inline search box next to the pills while the dropdown is
+  // open, otherwise long option lists (which are capped at 100 rendered options) are unsearchable.
+  const usePillSearch = !!multiple && displaySelectedAs === 'pill' && !freeText
+  const searchInputRef = useRef<HTMLInputElement>(null)
+
+  // Headless UI only writes back into the input when it decides the value is out of date, and it
+  // skips that while the user is mid-typing. Clear the field ourselves so the visible text can
+  // never disagree with the query the list is actually filtered by.
+  function clearSearch() {
+    setQuery('')
+    if (searchInputRef.current) searchInputRef.current.value = ''
+  }
+
+  // Single-select pill comboboxes swap the pill for a text input when the dropdown opens, and
+  // Headless UI has already pre-filled that input with the current selection's name. Typing then
+  // appends to that name ("Jane Doe" + "bob") and matches nothing, so the list can't be searched
+  // without manually clearing the field first. Start every pill dropdown with an empty query;
+  // Headless UI restores the display value on close.
+  const clearSearchOnOpen = displaySelectedAs === 'pill' && !freeText && !readOnly
+
   const filteredOptions =
     query === ''
       ? options
       : [
-          ...options.filter((option) => {
-            const value = displayIndex ? option.value?.[displayIndex] : option.value
-            return value?.toLowerCase().includes(query.toLowerCase())
-          }),
+          ...filterComboboxOptions({ options, query, displayIndex, secondaryDisplayIndex }),
           ...(freeText ? [{ value: query, disabled: false }] : []),
         ]
 
@@ -909,24 +973,30 @@ export function MercoaCombobox({
         <Combobox.Button className="mercoa-relative mercoa-w-full mercoa-bg-white" as="div">
           {({ open }) => {
             const showInput = displaySelectedAs === 'input' || freeText || (open && !multiple)
+            const showPillSearch = usePillSearch && open && !readOnly
             return (
               <>
+                {clearSearchOnOpen && <ClearSearchOnOpen open={open} onOpen={clearSearch} />}
                 <div className={!showInput ? inputBoxClass : ' '}>
                   {!showInput && displayPillValue(selectedValue)}
                   <Combobox.Input
-                    placeholder={placeholder}
+                    placeholder={showPillSearch ? 'Search...' : placeholder}
                     autoComplete="off"
                     className={
                       showInput
                         ? inputBoxClass
-                        : `${
-                            selectedValue && suppliedInputClassName
-                              ? 'mercoa-hidden'
-                              : 'mercoa-invisible mercoa-h-[0px] mercoa-p-0'
-                          }`
+                        : showPillSearch
+                          ? 'mercoa-inline-block mercoa-w-[120px] mercoa-border-0 mercoa-bg-transparent mercoa-p-0 mercoa-align-middle mercoa-text-sm mercoa-text-gray-900 placeholder:mercoa-text-gray-400 focus:mercoa-outline-none focus:mercoa-ring-0'
+                          : `${
+                              selectedValue && suppliedInputClassName
+                                ? 'mercoa-hidden'
+                                : 'mercoa-invisible mercoa-h-[0px] mercoa-p-0'
+                            }`
                     }
+                    ref={searchInputRef}
                     onChange={(event) => setQuery(event.target.value)}
-                    displayValue={displayInputValue}
+                    // Keep the field showing the live query; the selection is already shown as pills.
+                    displayValue={usePillSearch ? () => query : displayInputValue}
                     onClick={(e: any) => {
                       if (open) e.stopPropagation()
                     }}
@@ -942,7 +1012,7 @@ export function MercoaCombobox({
           }}
         </Combobox.Button>
 
-        {filteredOptionsLimited.length > 0 && (
+        {(filteredOptionsLimited.length > 0 || query !== '') && (
           <Combobox.Options
             className={
               'mercoa-absolute mercoa-z-10 mercoa-mt-1 mercoa-max-h-60 mercoa-w-full mercoa-overflow-auto mercoa-rounded-mercoa mercoa-bg-white mercoa-py-1 mercoa-text-base mercoa-shadow-lg mercoa-ring-1 mercoa-ring-black mercoa-ring-opacity-5 focus:mercoa-outline-none sm:mercoa-text-sm ' +
@@ -1028,6 +1098,17 @@ export function MercoaCombobox({
                 }}
               </Combobox.Option>
             )}
+            {filteredOptionsLimited.length === 0 && query !== '' && (
+              <Combobox.Option
+                className="mercoa-relative mercoa-cursor-default mercoa-select-none mercoa-py-2 mercoa-pl-3 mercoa-pr-9 mercoa-text-gray-600"
+                disabled
+                value=""
+              >
+                <div className="mercoa-flex mercoa-justify-center mercoa-py-2">
+                  <span className="mercoa-text-gray-500">No results found</span>
+                </div>
+              </Combobox.Option>
+            )}
             {filteredOptionsLimited.length != filteredOptions.length && (
               <Combobox.Option
                 className="mercoa-relative mercoa-cursor-default mercoa-select-none mercoa-py-2 mercoa-pl-3 mercoa-pr-9 mercoa-bg-gray-200 mercoa-text-gray-600"
@@ -1054,6 +1135,8 @@ export function MercoaCombobox({
       value={selectedValue}
       onChange={(value: any) => {
         setSelectedValue(value)
+        // Reset the search after each pick so the next one starts from the full list
+        if (usePillSearch) clearSearch()
         onChange(value)
       }}
       multiple


### PR DESCRIPTION
Ports the `MercoaCombobox` search fixes from [mercoa-finance/core#1703](https://github.com/mercoa-finance/core/pull/1703) and cuts **0.1.22**.

Needed on npm because the reporting customer (Hostfi / Avari Florida, 131 entity users) uses the **embedded components**, so a core deploy alone does not reach them.

## The two bugs

**1. Multi-select pill — the search box did not exist.** The approval-rules user picker is `multiple` + `displaySelectedAs="pill"`, and in that mode `showInput` is always false, so the input rendered as `mercoa-invisible mercoa-h-[0px]`. A `visibility: hidden` element **cannot receive focus**, so Headless UI's focus-the-input-on-open was a silent no-op — keystrokes went nowhere. Meanwhile the list caps at 100 rendered options and shows *"Showing first 100 results. Please type to search all results."*, pointing at a box that did not exist. Past user #100, an approver was unreachable.

**2. Single-select pill — typing appends to the current selection.** The per-invoice "Assigned to" picker and the bulk assign-approver dialog are *single*-select, so fix 1 does not reach them. Opening one swaps the pill for an input Headless UI has already pre-filled with the current selection's name, so typing appends:

```
"Dana Person2"  +  "Person142"   ->   "Dana Person2Person142"   ->   No results found
```

You can only search after manually clearing the field first, which nobody discovers.

## Changes

- Render the search input inline next to the pills while the dropdown is open (multi-select).
- Clear the query on the closed → open transition for pill comboboxes, so the dropdown always opens as an empty search field. Headless UI restores the display value on close, and the pill still shows the current selection while closed.
- Match the query against secondary display fields, so users are findable by **email** and roles by name.
- Show "No results found" instead of the options panel silently vanishing.
- Bump `version` to `0.1.22` so `publish.yml` actually releases on merge.

Scoped to `displaySelectedAs === 'pill'` (and not `freeText`/`readOnly`) — comboboxes that display their selection as input text are untouched, since blanking those would look like the value was lost.

## How this was produced

Generated with this repo's own `make sync` against core plus `npm run prettier`, then **reduced to just `generics.tsx`**. The full sync also pulls **12 unrelated files** of drift from core (`EntityDetails`, `EntityOnboarding`, `EntityPortal`, `PayableDetails`, `Payables`, `ReceivableDetails`, `ReceivableFormErrorsV1`, `ReceivablePaymentPdf`, `ReceivablePaymentPortal`, `Receivables`, `lib/lib.ts`, `payables-dashboard`). Those are already-merged core work that has not been released to npm, and they should go out as their own deliberate sync rather than riding along in an urgent customer-facing patch — flagging so someone can schedule that.

`generics.tsx` here is byte-identical to core's copy apart from the two `make sync` sed rewrites and nested-ternary indentation (this repo's prettier indents them deeper), so the next `make sync` stays a no-op on this file.

## Verification

- `npm run build` passes end to end (`tsc` → vite → tailwind → declaration files), and the new `Search...` affordance is present in the emitted bundles.
- `eslint src/components/generics.tsx`: **7 errors before, 7 after** — no new errors. Two new `no-explicit-any` *warnings* from `filterComboboxOptions`, deliberately left as-is to keep byte-parity with core (the file already carries 38 such warnings; diverging here would make `make sync` fight this file).
- Behaviour was verified in a real browser on the core branch against the actual component with 150 users, using props copied verbatim from the call sites: multi-select search by email finds a user past the 100-option cap, selecting adds/removes the pill and resets the search, single-select search works on first *and* subsequent opens, and roles / single-select-input comboboxes are unchanged.
- Unit tests for the extracted `filterComboboxOptions` (11 cases) live in core — this repo has no test runner configured, so they were not ported.

---

<div align="center">
<sub>
Created by <b>Sai Arora</b> (sai@mercoa.com) with <a href="https://tryreplicas.com">Replicas</a><br>
<a href="https://tryreplicas.com/workspaces/f3d0acb8-aa1e-4a6d-a967-a5cbd7878e8e">Workspace</a> &nbsp;·&nbsp; <a href="https://mercoa.slack.com/archives/C05HNLBNAF4/p1786123529205679?thread_ts=1786123529.205679&cid=C05HNLBNAF4">Slack Thread</a>
</sub>
</div>

Co-Authored-By: replicas-connector[bot] <replicas-connector[bot]@users.noreply.github.com>
